### PR TITLE
Allow dispatchable to be any type

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -36,7 +36,7 @@ func (s SelectOption[T]) Render(selected bool) *hypp.VNode {
 	)
 }
 
-var _ fairytale.Control[hypp.EmptyState] = &Select[hypp.EmptyState, struct{}]{}
+var _ fairytale.Control[struct{}] = &Select[struct{}, struct{}]{}
 
 // Select is a Control that lets you update the state by selecting one
 // of the available options.
@@ -91,9 +91,13 @@ func (s Select[S, T]) Render(
 		hypp.Text(s.label),
 		html.Select(
 			hypp.HProps{
-				"onchange": dispatch.ChangeControlAction[S](talePath, controlIndex, func(event window.Event) json.RawMessage {
-					return []byte(event.Target().Value())
-				}),
+				"onchange": dispatch.CreateChangeControlAction[S](
+					talePath,
+					controlIndex,
+					func(event window.Event) json.RawMessage {
+						return []byte(event.Target().Value())
+					},
+				),
 			},
 			options...,
 		),
@@ -118,7 +122,7 @@ func (s Select[S, T]) UpdateFromMessage(
 	return s.update(state, t)
 }
 
-var _ fairytale.Control[hypp.EmptyState] = &Checkbox[hypp.EmptyState]{}
+var _ fairytale.Control[struct{}] = &Checkbox[struct{}]{}
 
 // Checkbox is a Control that lets you update the state by toggling a
 // checkbox.
@@ -154,9 +158,13 @@ func (c Checkbox[S]) Render(
 			hypp.HProps{
 				"type":    "checkbox",
 				"checked": c.checked(state),
-				"onchange": dispatch.ChangeControlAction[S](path, controlIndex, func(event window.Event) bool {
-					return event.Value.Get("target").Get("checked").Bool()
-				}),
+				"onchange": dispatch.CreateChangeControlAction[S](
+					path,
+					controlIndex,
+					func(event window.Event) bool {
+						return event.Value.Get("target").Get("checked").Bool()
+					},
+				),
 			},
 		),
 	)
@@ -176,7 +184,7 @@ func (c Checkbox[S]) UpdateFromMessage(
 	return c.update(state, checked)
 }
 
-var _ fairytale.Control[hypp.EmptyState] = &NumberInput[hypp.EmptyState, float64]{}
+var _ fairytale.Control[struct{}] = &NumberInput[struct{}, float64]{}
 
 type Number interface {
 	constraints.Integer | constraints.Float
@@ -228,9 +236,13 @@ func (n NumberInput[S, N]) Render(
 	inputProps := hypp.HProps{
 		"type":  "number",
 		"value": fmt.Sprint(n.value(state)),
-		"onchange": dispatch.ChangeControlAction[S](path, controlIndex, func(event window.Event) N {
-			return n.parseNumber([]byte(event.Target().Value()))
-		}),
+		"onchange": dispatch.CreateChangeControlAction[S](
+			path,
+			controlIndex,
+			func(event window.Event) N {
+				return n.parseNumber([]byte(event.Target().Value()))
+			},
+		),
 	}
 	if n.min != nil {
 		inputProps["min"] = fmt.Sprint(*n.min)
@@ -273,7 +285,7 @@ func (n NumberInput[S, N]) UpdateFromMessage(
 	return n.update(state, number)
 }
 
-var _ fairytale.Control[hypp.EmptyState] = &TextInput[hypp.EmptyState]{}
+var _ fairytale.Control[struct{}] = &TextInput[struct{}]{}
 
 type TextInput[S hypp.State] struct {
 	label     string
@@ -309,9 +321,13 @@ func (t TextInput[S]) Render(state S, path []int, controlIndex int) *hypp.VNode 
 	inputProps := hypp.HProps{
 		"type":  "text",
 		"value": t.value(state),
-		"oninput": dispatch.ChangeControlAction[S](path, controlIndex, func(event window.Event) string {
-			return event.Target().Value()
-		}),
+		"oninput": dispatch.CreateChangeControlAction[S](
+			path,
+			controlIndex,
+			func(event window.Event) string {
+				return event.Target().Value()
+			},
+		),
 	}
 	if t.minLength != nil {
 		inputProps["minlength"] = strconv.Itoa(*t.minLength)
@@ -342,7 +358,7 @@ func (t TextInput[S]) UpdateFromMessage(
 	return t.update(state, text)
 }
 
-var _ fairytale.Control[hypp.EmptyState] = &Button[hypp.EmptyState]{}
+var _ fairytale.Control[struct{}] = &Button[struct{}]{}
 
 // Button is a Control that lets you update the state by clicking a
 // button.
@@ -371,7 +387,7 @@ func (c Button[S]) Render(
 	return html.Button(
 		hypp.HProps{
 			"type": "button",
-			"onclick": dispatch.ChangeControlAction[S](
+			"onclick": dispatch.CreateChangeControlAction[S](
 				path,
 				controlIndex,
 				func(_ window.Event) struct{} {
@@ -391,7 +407,7 @@ func (c Button[S]) UpdateFromMessage(state S, _ json.RawMessage) hypp.Dispatchab
 	return c.update(state)
 }
 
-var _ fairytale.Control[hypp.EmptyState] = &Textarea[hypp.EmptyState]{}
+var _ fairytale.Control[struct{}] = &Textarea[struct{}]{}
 
 type Textarea[S hypp.State] struct {
 	label   string
@@ -425,9 +441,13 @@ func (t *Textarea[S]) WithColumns(columns int) *Textarea[S] {
 
 func (t Textarea[S]) Render(state S, path []int, controlIndex int) *hypp.VNode {
 	hProps := hypp.HProps{
-		"oninput": dispatch.ChangeControlAction[S](path, controlIndex, func(event window.Event) string {
-			return event.Target().Value()
-		}),
+		"oninput": dispatch.CreateChangeControlAction[S](
+			path,
+			controlIndex,
+			func(event window.Event) string {
+				return event.Target().Value()
+			},
+		),
 	}
 	if t.rows != nil {
 		hProps["rows"] = *t.rows

--- a/internal/component/iframesizeselect.go
+++ b/internal/component/iframesizeselect.go
@@ -23,7 +23,7 @@ func IFrameSizeSelect[S hypp.State](selectedSize fairytale.IFrameSize) *hypp.VNo
 		hypp.Text("Size"),
 		html.Select(
 			hypp.HProps{
-				"onchange": dispatch.SelectIFrameSizeAction[S](),
+				"onchange": dispatch.SelectIFrameSize[S],
 			},
 			options...,
 		),

--- a/internal/component/paneltabs.go
+++ b/internal/component/paneltabs.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"github.com/macabot/fairytale"
 	"github.com/macabot/fairytale/internal/dispatch"
 	"github.com/macabot/hypp"
 	"github.com/macabot/hypp/tag/html"
@@ -24,7 +25,10 @@ func PanelTab[S hypp.State](i int, name string, selected bool) *hypp.VNode {
 				"panel-tab": true,
 				"selected":  selected,
 			},
-			"onclick": dispatch.SelectPanelTabAction[S](i),
+			"onclick": hypp.ActionAndPayload[*fairytale.State[S]]{
+				Action:  dispatch.SelectPanelTab[S],
+				Payload: i,
+			},
 		},
 		hypp.Text(name),
 	)

--- a/internal/component/rotationselect.go
+++ b/internal/component/rotationselect.go
@@ -23,7 +23,7 @@ func OrientationSelect[S hypp.State](selectedOrientation fairytale.Orientation) 
 		hypp.Text("Orientation"),
 		html.Select(
 			hypp.HProps{
-				"onchange": dispatch.SelectOrientationAction[S](),
+				"onchange": dispatch.SelectOrientation[S],
 			},
 			options...,
 		),

--- a/internal/dispatch/app.go
+++ b/internal/dispatch/app.go
@@ -10,13 +10,11 @@ func RefreshAppSubscription[S hypp.State]() hypp.Subscription {
 		Subscriber: subscribeToWindowMessage,
 		Payload: windowMessageProps{
 			Type:         windowMessageRefreshApp,
-			Dispatchable: refreshAppAction[S](),
+			Dispatchable: refreshApp[S],
 		},
 	}
 }
 
-func refreshAppAction[S hypp.State]() hypp.Action[*fairytale.State[S]] {
-	return func(s *fairytale.State[S], _ hypp.Payload) hypp.Dispatchable {
-		return s.Clone()
-	}
+func refreshApp[S hypp.State](s *fairytale.State[S], _ hypp.Payload) hypp.Dispatchable {
+	return s.Clone()
 }

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -15,7 +15,7 @@ type operateControlData[T any] struct {
 	EventData    T
 }
 
-func ChangeControlAction[S hypp.State, T any](
+func CreateChangeControlAction[S hypp.State, T any](
 	talePath []int,
 	controlIndex int,
 	getEventData func(window.Event) T,
@@ -45,21 +45,19 @@ func OperateControlSubscription[S hypp.State]() hypp.Subscription {
 		Subscriber: subscribeToWindowMessage,
 		Payload: windowMessageProps{
 			Type:         windowMessageOperateControl,
-			Dispatchable: operateControlAction[S](),
+			Dispatchable: operateControl[S],
 		},
 	}
 }
 
-func operateControlAction[S hypp.State]() hypp.Action[*fairytale.State[S]] {
-	return func(s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
-		raw := payload.(json.RawMessage)
-		var data operateControlData[json.RawMessage]
-		if err := json.Unmarshal(raw, &data); err != nil {
-			panic(fmt.Errorf("fairytale: cannot unmarshal operateControl data '%s': %w", string(raw), err))
-		}
-		tale := s.GetTale(data.TalePath)
-		control := tale.Controls()[data.ControlIndex]
-		tale.Dispatch(control.UpdateFromMessage(tale.State(), data.EventData), payload)
-		return s.Clone()
+func operateControl[S hypp.State](s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
+	raw := payload.(json.RawMessage)
+	var data operateControlData[json.RawMessage]
+	if err := json.Unmarshal(raw, &data); err != nil {
+		panic(fmt.Errorf("fairytale: cannot unmarshal operateControl data '%s': %w", string(raw), err))
 	}
+	tale := s.GetTale(data.TalePath)
+	control := tale.Controls()[data.ControlIndex]
+	tale.Dispatch(control.UpdateFromMessage(tale.State(), data.EventData), payload)
+	return s.Clone()
 }

--- a/internal/dispatch/hash.go
+++ b/internal/dispatch/hash.go
@@ -18,7 +18,7 @@ func HashChangeSubscription[S hypp.State]() hypp.Subscription {
 				if err != nil {
 					panic(err)
 				}
-				dispatch(updateCurrentFromLocationAction[S](u), nil)
+				dispatch(updateCurrentFromLocation[S], u)
 			}
 			id := window.AddEventListener("hashchange", listener)
 			return func() {
@@ -28,14 +28,13 @@ func HashChangeSubscription[S hypp.State]() hypp.Subscription {
 	}
 }
 
-func updateCurrentFromLocationAction[S hypp.State](u *url.URL) hypp.Action[*fairytale.State[S]] {
-	return func(s *fairytale.State[S], _ hypp.Payload) hypp.Dispatchable {
-		newState := s.Clone()
-		newState.UpdateCurrentFromURL(u)
-		postWindowMessageToIFrame(windowMessage[[]int]{
-			Type: windowMessageSelectTale,
-			Data: newState.Current(),
-		})
-		return newState
-	}
+func updateCurrentFromLocation[S hypp.State](s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
+	u := payload.(*url.URL)
+	newState := s.Clone()
+	newState.UpdateCurrentFromURL(u)
+	postWindowMessageToIFrame(windowMessage[[]int]{
+		Type: windowMessageSelectTale,
+		Data: newState.Current(),
+	})
+	return newState
 }

--- a/internal/dispatch/iframesize.go
+++ b/internal/dispatch/iframesize.go
@@ -6,20 +6,18 @@ import (
 	"github.com/macabot/hypp/window"
 )
 
-func SelectIFrameSizeAction[S hypp.State]() hypp.Action[*fairytale.State[S]] {
-	return func(s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
-		event := payload.(window.Event)
-		value := event.Target().Value()
-		size := fairytale.MustIFrameSizeFromString(value)
+func SelectIFrameSize[S hypp.State](s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
+	event := payload.(window.Event)
+	value := event.Target().Value()
+	size := fairytale.MustIFrameSizeFromString(value)
 
-		settings := s.Settings()
-		settings.IFrameSize = size
-		newState := s.Clone()
-		newState.SetSettings(settings)
-		postWindowMessageToIFrame(windowMessage[struct{}]{
-			Type: windowMessageRefreshApp,
-			Data: struct{}{},
-		})
-		return newState
-	}
+	settings := s.Settings()
+	settings.IFrameSize = size
+	newState := s.Clone()
+	newState.SetSettings(settings)
+	postWindowMessageToIFrame(windowMessage[struct{}]{
+		Type: windowMessageRefreshApp,
+		Data: struct{}{},
+	})
+	return newState
 }

--- a/internal/dispatch/paneltab.go
+++ b/internal/dispatch/paneltab.go
@@ -5,10 +5,9 @@ import (
 	"github.com/macabot/hypp"
 )
 
-func SelectPanelTabAction[S hypp.State](i int) hypp.Action[*fairytale.State[S]] {
-	return func(s *fairytale.State[S], _ hypp.Payload) hypp.Dispatchable {
-		newState := s.Clone()
-		newState.SetSelectedPanelTab(i)
-		return newState
-	}
+func SelectPanelTab[S hypp.State](s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
+	i := payload.(int)
+	newState := s.Clone()
+	newState.SetSelectedPanelTab(i)
+	return newState
 }

--- a/internal/dispatch/rotation.go
+++ b/internal/dispatch/rotation.go
@@ -6,20 +6,18 @@ import (
 	"github.com/macabot/hypp/window"
 )
 
-func SelectOrientationAction[S hypp.State]() hypp.Action[*fairytale.State[S]] {
-	return func(s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
-		event := payload.(window.Event)
-		value := event.Target().Value()
-		orientation := fairytale.MustOrientationFromString(value)
+func SelectOrientation[S hypp.State](s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
+	event := payload.(window.Event)
+	value := event.Target().Value()
+	orientation := fairytale.MustOrientationFromString(value)
 
-		settings := s.Settings()
-		settings.Orientation = orientation
-		newState := s.Clone()
-		newState.SetSettings(settings)
-		postWindowMessageToIFrame(windowMessage[struct{}]{
-			Type: windowMessageRefreshApp,
-			Data: struct{}{},
-		})
-		return newState
-	}
+	settings := s.Settings()
+	settings.Orientation = orientation
+	newState := s.Clone()
+	newState.SetSettings(settings)
+	postWindowMessageToIFrame(windowMessage[struct{}]{
+		Type: windowMessageRefreshApp,
+		Data: struct{}{},
+	})
+	return newState
 }

--- a/internal/dispatch/tale.go
+++ b/internal/dispatch/tale.go
@@ -13,24 +13,22 @@ func TaleEventSubscription[S hypp.State]() hypp.Subscription {
 		Subscriber: subscribeToWindowMessage,
 		Payload: windowMessageProps{
 			Type:         windowMessageTaleEvent,
-			Dispatchable: appendTaleEventAction[S](),
+			Dispatchable: appendTaleEvent[S],
 		},
 	}
 }
 
-func appendTaleEventAction[S hypp.State]() hypp.Action[*fairytale.State[S]] {
-	return func(s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
-		raw := payload.(json.RawMessage)
-		var event fairytale.TaleEvent[S]
-		if err := json.Unmarshal(raw, &event); err != nil {
-			panic(fmt.Errorf("fairytale: cannot unmarshal appendTaleEvent data '%s': %w", string(raw), err))
-		}
-
-		newState := s.Clone()
-		tale := newState.GetTale(event.Path)
-		tale.SetState(event.State)
-		return newState
+func appendTaleEvent[S hypp.State](s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
+	raw := payload.(json.RawMessage)
+	var event fairytale.TaleEvent[S]
+	if err := json.Unmarshal(raw, &event); err != nil {
+		panic(fmt.Errorf("fairytale: cannot unmarshal appendTaleEvent data '%s': %w", string(raw), err))
 	}
+
+	newState := s.Clone()
+	tale := newState.GetTale(event.Path)
+	tale.SetState(event.State)
+	return newState
 }
 
 func TaleStateSubscription[S hypp.State](tale *fairytale.Tale[S], path []int) hypp.Subscription {
@@ -55,7 +53,7 @@ func TaleStateSubscription[S hypp.State](tale *fairytale.Tale[S], path []int) hy
 	}
 }
 
-func taleDispatchAction[S hypp.State](
+func createTaleDispatchAction[S hypp.State](
 	tale *fairytale.Tale[S],
 	dispatchable hypp.Dispatchable,
 ) hypp.Action[*fairytale.State[S]] {
@@ -77,7 +75,7 @@ func TriggerTaleEvent[S hypp.State](
 		return value
 	}
 
-	return taleDispatchAction(tale, dispatchable)
+	return createTaleDispatchAction(tale, dispatchable)
 }
 
 func equalPaths(a, b []int) bool {
@@ -97,23 +95,21 @@ func SelectTaleSubscription[S hypp.State]() hypp.Subscription {
 		Subscriber: subscribeToWindowMessage,
 		Payload: windowMessageProps{
 			Type:         windowMessageSelectTale,
-			Dispatchable: selectTaleAction[S](),
+			Dispatchable: selectTale[S],
 		},
 	}
 }
 
-func selectTaleAction[S hypp.State]() hypp.Action[*fairytale.State[S]] {
-	return func(s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
-		raw := payload.(json.RawMessage)
-		var path []int
-		if err := json.Unmarshal(raw, &path); err != nil {
-			panic(fmt.Errorf("fairytale: cannot unmarshal selectTale data '%s': %w", string(raw), err))
-		}
-		if equalPaths(path, s.Current()) {
-			return s
-		}
-		newState := s.Clone()
-		newState.SetCurrent(path)
-		return newState
+func selectTale[S hypp.State](s *fairytale.State[S], payload hypp.Payload) hypp.Dispatchable {
+	raw := payload.(json.RawMessage)
+	var path []int
+	if err := json.Unmarshal(raw, &path); err != nil {
+		panic(fmt.Errorf("fairytale: cannot unmarshal selectTale data '%s': %w", string(raw), err))
 	}
+	if equalPaths(path, s.Current()) {
+		return s
+	}
+	newState := s.Clone()
+	newState.SetCurrent(path)
+	return newState
 }

--- a/node.go
+++ b/node.go
@@ -15,7 +15,7 @@ type Node[S hypp.State] interface {
 	SetIsOpen(bool)
 }
 
-var _ Node[hypp.EmptyState] = &Bundle[hypp.EmptyState]{}
+var _ Node[struct{}] = &Bundle[struct{}]{}
 
 // Bundle forms a bundle of Nodes.
 type Bundle[S hypp.State] struct {

--- a/state.go
+++ b/state.go
@@ -14,7 +14,6 @@ type AdminSettings struct {
 }
 
 type State[S hypp.State] struct {
-	hypp.EmptyState
 	tree             Node[S]
 	current          []int
 	settings         AdminSettings

--- a/tale.go
+++ b/tale.go
@@ -21,7 +21,7 @@ type TaleSettings struct {
 	Target TaleTarget
 }
 
-var _ Node[hypp.EmptyState] = &Tale[hypp.EmptyState]{}
+var _ Node[struct{}] = &Tale[struct{}]{}
 
 // Control manages the state of a Tale. Typically, a Control manages a single
 // property of the state, however a Control can change the whole state.
@@ -66,12 +66,14 @@ func New[S hypp.State](
 			}
 		case hypp.Action[S]:
 			dispatch(v(tale.state, payload), nil)
+		case func(S, hypp.Payload) hypp.Dispatchable:
+			dispatch(v(tale.state, payload), nil)
 		case hypp.ActionAndPayload[S]:
 			dispatch(v.Action, v.Payload)
 		case S:
 			tale.SetState(v)
 		default:
-			panic(fmt.Errorf("fairytale: dispatchable has unexpected type '%[1]T'. Expected type 'StateAndEffects[%[2]T]', 'Action[%[2]T]', 'ActionAndPayload[%[2]T]' or '%[2]T'", dispatchable, tale.state))
+			panic(fmt.Errorf("fairytale: dispatchable has unexpected type '%[1]T'. Expected type 'StateAndEffects[%[2]T]', 'Action[%[2]T]', 'func(%[2]T, Payload) Dispatchable', 'ActionAndPayload[%[2]T]' or '%[2]T'", dispatchable, tale.state))
 		}
 	}
 	tale = &Tale[S]{


### PR DESCRIPTION
Changes correspond to https://github.com/macabot/hypp/pull/42
- References to hypp.EmptyState have been removed.
- Functions that returned an action have been refactored to be the action.